### PR TITLE
Add review-pr script for gh-review-watcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,15 @@ Note: The configuration uses experimental Nix features (flakes) which must be en
 - Import it in `nix/home-manager/default.nix`
 - See wezterm configuration as an example
 
+## Compact Instructions
+
+When compacting, preserve the following:
+- Current task context and goals
+- File paths being edited and their purpose
+- Test results and error messages
+- Decisions already made and their rationale
+- Key variable names and function signatures being worked on
+
 ## Important Notes
 
 - The Neovim configuration references a symlink to `${pwd}/conf` which points to `~/dotfiles-nix/home-manager/console/neovim/conf` - this path may need adjustment

--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774612830,
-        "narHash": "sha256-cWeOR6cVvAK4waoz5cxU4pUMJHcFh9wMVnR0Lr/Acwo=",
+        "lastModified": 1774850197,
+        "narHash": "sha256-jA0SW5uZxLy+XCV7Uvf0DSk/l60kF0Prho5j6yLy7EY=",
         "owner": "EdV4H",
         "repo": "gh-review-watcher",
-        "rev": "b8d093b9d2906e3f90d27873548caacf3d66971b",
+        "rev": "61ae050790df00d1f46d4e848db47487ff1c9c2d",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774584114,
-        "narHash": "sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw=",
+        "lastModified": 1774738535,
+        "narHash": "sha256-2jfBEZUC67IlnxO5KItFCAd7Oc+1TvyV/jQlR+2ykGQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4b1be5c38be350ee9452a4847945ce71d950dc31",
+        "rev": "769e07ef8f4cf7b1ec3b96ef015abec9bc6b1e2a",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1774570021,
-        "narHash": "sha256-wsYvPHx2/PcZqSWh1yZL3p7YA5lzaZQwDxpbWAYu/70=",
+        "lastModified": 1774829101,
+        "narHash": "sha256-iOJHT8hP9IurF6gnvyEL6NVeMmDKvlCxwuKtPhXAt00=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "2e94080a884c108044aa349cb0f4b77033cda940",
+        "rev": "a49f9d17bcaa684b81fc4322fbcbfc3ba501d40e",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774546966,
-        "narHash": "sha256-uIFX2x4sg2Cmkp5IsamABr/8+PsNsYUqqH16F00Pt/A=",
+        "lastModified": 1774827424,
+        "narHash": "sha256-Jd05KifFViRnFmSc8Wi58VQXDfaKvwmly1e9olXlefw=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ae2829ee35c1fb8649f9d4046c5af48987193d03",
+        "rev": "ed822a085db0b6f4c682707be2c35a7acdca57b2",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1774309640,
-        "narHash": "sha256-8oWL7YLwElBY9ebYri1LlSlhf/gd1Qoqj0nbBwG2yso=",
+        "lastModified": 1774802402,
+        "narHash": "sha256-L1UJ/zxKTyyaGGmytH6OYlgQ0HGSMhvPkvU+iz4Mkb8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "28c58bf023bf537354f78d6e496a349d7a0ed554",
+        "rev": "cbd8536a05d1aae2593cb5c9ace1010c8c5845cb",
         "type": "github"
       },
       "original": {

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -67,6 +67,7 @@ in
       VOLTA_FEATURE_PNPM = "1";
       GOOGLE_CLOUD_PROJECT = "atrae-engineer-gu7335mbf";
       GOENV_ROOT = "$HOME/.goenv";
+      CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "65";
     };
 
     sessionPath = [
@@ -129,6 +130,12 @@ in
   # Daily report generator script
   home.file.".local/bin/daily-report" = {
     source = ./programs/claude-code/daily-report.sh;
+    executable = true;
+  };
+
+  # PR review script (triggered by gh-review-watcher)
+  home.file.".local/bin/review-pr" = {
+    source = ./programs/claude-code/review-pr.sh;
     executable = true;
   };
 

--- a/nix/home-manager/programs/claude-code/review-pr.sh
+++ b/nix/home-manager/programs/claude-code/review-pr.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="$1"
+NUMBER="$2"
+REPO="$3"
+
+echo "🔍 Reviewing PR #${NUMBER} in ${REPO}..."
+echo ""
+
+# Step 1: claude -p でレビュー実行、結果を表示
+claude --dangerously-skip-permissions -p "/review ${URL}" 2>&1
+echo ""
+
+# Step 2: 選択肢を提示
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  [a] Approve this PR"
+echo "  [d] Discuss with Claude Code"
+echo "  [o] Open in browser"
+echo "  [q] Quit"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+read -r -p "Choose action: " choice
+
+case "$choice" in
+  a)
+    gh pr review "$NUMBER" -R "$REPO" --approve --body "LGTM 👍 (Reviewed by Claude Code)"
+    echo "✅ Approved!"
+    ;;
+  d)
+    exec claude --dangerously-skip-permissions \
+      "PR #${NUMBER} (${REPO}) について議論しましょう。URL: ${URL}"
+    ;;
+  o)
+    open "$URL"
+    ;;
+  q)
+    exit 0
+    ;;
+esac

--- a/nix/home-manager/programs/claude-code/skills/worktree-cleanup/SKILL.md
+++ b/nix/home-manager/programs/claude-code/skills/worktree-cleanup/SKILL.md
@@ -153,6 +153,11 @@ zellij action rename-pane "$NEW_BRANCH"
 - 最新コミット: <hash> <message>
 ```
 
+### Step 11: コンテキスト削減
+
+タスク完了後、`/compact` を実行してコンテキストを圧縮する。
+worktree-cleanupは作業の区切りなので、前のworktreeでの作業履歴を積極的に削減する。
+
 ## 注意事項
 
 - **`git worktree remove` は取り消せない** — 未コミットの変更がある場合は必ずユーザーに確認


### PR DESCRIPTION
## Summary
- gh-review-watcherの`on_new_pr` hookから起動されるPRレビュースクリプトを追加
- `claude -p '/review'` でAIレビュー実行後、アクション選択メニューを表示
  - `[a]` Approve: `gh pr review --approve` を実行
  - `[d]` Discuss: Claude Codeを対話モードで起動して議論を継続
  - `[o]` Open: ブラウザでPRを開く
  - `[q]` Quit: 終了
- zellijの新しいタブで開くことでCockpitレイアウトを邪魔しない
- Nix home-managerで `~/.local/bin/review-pr` に配置

## Test plan
- [ ] `review-pr <url> <number> <repo>` を手動実行してレビューが走ることを確認
- [ ] 各選択肢(a/d/o/q)が正しく動作することを確認
- [ ] gh-review-watcherで実際にPR検出時にタブが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)